### PR TITLE
Add _input and _unhandled_input processing to SM

### DIFF
--- a/addons/state_machine_nodes/state_machine.gd
+++ b/addons/state_machine_nodes/state_machine.gd
@@ -108,6 +108,12 @@ func get_state_node(state_name: String) -> StateNode:
 func get_state_list() -> Array[String]:
 	return __state_table.keys()
 
+## Calls [method StateNode._unhandled_input_state] on the current [StateNode].
+func unhandled_input(event: InputEvent) -> void:
+	if is_instance_valid(__state_node):
+		var new_state: String = __state_node._unhandled_input_state(event)
+		if not new_state.is_empty():
+			set_state(new_state)
 
 ## Calls [method StateNode._process_state] on the current [StateNode].
 ## [br][br]
@@ -183,6 +189,9 @@ func _notification(what: int) -> void:
 		NOTIFICATION_PHYSICS_PROCESS:
 			if auto_process:
 				physics_process_state(get_physics_process_delta_time())
+
+func _unhandled_input(event: InputEvent) -> void:
+	unhandled_input(event)
 
 #endregion
 #region Getters & Setters

--- a/addons/state_machine_nodes/state_machine.gd
+++ b/addons/state_machine_nodes/state_machine.gd
@@ -108,6 +108,13 @@ func get_state_node(state_name: String) -> StateNode:
 func get_state_list() -> Array[String]:
 	return __state_table.keys()
 
+## Calls [method StateNode._input_state] on the current [StateNode].
+func input(event: InputEvent) -> void:
+	if is_instance_valid(__state_node):
+		var new_state: String = __state_node._input_state(event)
+		if not new_state.is_empty():
+			set_state(new_state)
+
 ## Calls [method StateNode._unhandled_input_state] on the current [StateNode].
 func unhandled_input(event: InputEvent) -> void:
 	if is_instance_valid(__state_node):
@@ -189,6 +196,9 @@ func _notification(what: int) -> void:
 		NOTIFICATION_PHYSICS_PROCESS:
 			if auto_process:
 				physics_process_state(get_physics_process_delta_time())
+
+func _input(event: InputEvent) -> void:
+	input(event)
 
 func _unhandled_input(event: InputEvent) -> void:
 	unhandled_input(event)

--- a/addons/state_machine_nodes/state_node.gd
+++ b/addons/state_machine_nodes/state_node.gd
@@ -15,7 +15,8 @@ class_name StateNode extends Node
 ## The following methods can be overriden to add and extend logic:
 ## [method _process_state], [method _physics_process_state],
 ## [method _enter_state], [method _exit_state],
-## [method _state_machine_ready].
+## [method _state_machine_ready], [method _input_state],
+## [method _unhandled_input_state].
 
 
 var __state_machine: StateMachine
@@ -49,6 +50,13 @@ func _enter_state(previous_state: String) -> void:
 @warning_ignore("unused_parameter")
 func _exit_state(next_state: String) -> void:
 	pass
+
+## [b]<OVERRIDABLE>[/b][br][br]
+## Called by a [StateMachine] when _input is called.
+## [param event] is the [InputEvent] that was received.
+@warning_ignore("unused_parameter")
+func _input_state(event: InputEvent) -> String:
+	return ""
 
 ## [b]<OVERRIDABLE>[/b][br][br]
 ## Called by a [StateMachine] when _unhandled_input is called.

--- a/addons/state_machine_nodes/state_node.gd
+++ b/addons/state_machine_nodes/state_node.gd
@@ -50,6 +50,12 @@ func _enter_state(previous_state: String) -> void:
 func _exit_state(next_state: String) -> void:
 	pass
 
+## [b]<OVERRIDABLE>[/b][br][br]
+## Called by a [StateMachine] when _unhandled_input is called.
+## [param event] is the [InputEvent] that was received.
+@warning_ignore("unused_parameter")
+func _unhandled_input_state(event: InputEvent) -> String:
+	return ""
 
 ## [b]<OVERRIDABLE>[/b][br][br]
 ## Called by a [StateMachine] each process frame (idle) with the

--- a/examples/state_machine_nodes/states/crouch.gd
+++ b/examples/state_machine_nodes/states/crouch.gd
@@ -8,10 +8,15 @@ func _enter_state(_previous_state: String) -> void:
 func _physics_process_state(_delta: float) -> String:
 	if player.is_on_floor():
 		player.velocity.x = move_toward(player.velocity.x, 0.0, SPEED * 0.025)
-		
-		if Input.is_action_just_released(&"crouch"):
-			return get_state_machine().get_previous_state()
+
 	else:
 		return "Fall"
-	
+
+	return ""
+
+
+func _unhandled_input_state(event: InputEvent) -> String:
+	if event.is_action_released(&"crouch"):
+		get_viewport().set_input_as_handled()
+		return get_state_machine().get_previous_state()
 	return ""

--- a/examples/state_machine_nodes/states/idle.gd
+++ b/examples/state_machine_nodes/states/idle.gd
@@ -9,11 +9,17 @@ func _physics_process_state(_delta: float) -> String:
 	if player.is_on_floor():
 		if Input.get_axis(&"walk_left", &"walk_right") != 0.0:
 			return "Walk"
-		elif Input.is_action_just_pressed(&"jump"):
-			return "Jump"
-		elif Input.is_action_just_pressed(&"crouch"):
-			return "Crouch"
 	else:
 		return "Fall"
-	
+
+	return ""
+
+
+func _unhandled_input_state(event: InputEvent) -> String:
+	if event.is_action_pressed(&"jump"):
+		get_viewport().set_input_as_handled()
+		return "Jump"
+	if event.is_action_pressed(&"crouch"):
+		get_viewport().set_input_as_handled()
+		return "Crouch"
 	return ""

--- a/examples/state_machine_nodes/states/walk.gd
+++ b/examples/state_machine_nodes/states/walk.gd
@@ -13,14 +13,20 @@ func _physics_process_state(_delta: float) -> String:
 			player.velocity.x = move_toward(player.velocity.x, SPEED * direction, SPEED * 0.05)
 		else:
 			player.velocity.x = move_toward(player.velocity.x, 0.0, SPEED * 0.05)
-	
+
 		if direction == 0.0 and is_zero_approx(player.velocity.x):
 			return "Idle"
-		elif Input.is_action_just_pressed(&"jump"):
-			return "Jump"
-		elif Input.is_action_just_pressed(&"crouch"):
-			return "Crouch"
 	else:
 		return "Fall"
-	
+
+	return ""
+
+
+func _unhandled_input_state(event: InputEvent) -> String:
+	if event.is_action_pressed(&"jump"):
+		get_viewport().set_input_as_handled()
+		return "Jump"
+	if event.is_action_pressed(&"crouch"):
+		get_viewport().set_input_as_handled()
+		return "Crouch"
 	return ""


### PR DESCRIPTION
It is useful to be able to have the state machine handle these callbacks as it is more  efficient than polling the Input singleton on every `process` or `physics_process` call. I updated the example project where appropriate to test and demonstrate the new capability. 